### PR TITLE
Added VSIX Fix to include Frameworks.xml

### DIFF
--- a/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
+++ b/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
@@ -78,6 +78,10 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\SharedFiles\Frameworks.xml">
+      <Link>Frameworks.xml</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="..\SharedFiles\Resources\Images.png">
       <Link>Resources\Images.png</Link>
       <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
Added Frameworks.xml to VS2022 VSIX installer. This was missing, causing the execution to fail.