### PR TITLE
Vs2022: Attempt to fix continous integration

### DIFF
--- a/Src/TargetFrameworkMigrator.VS2022/TargetFrameworkMigrator.VS2022.csproj
+++ b/Src/TargetFrameworkMigrator.VS2022/TargetFrameworkMigrator.VS2022.csproj
@@ -26,6 +26,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+	<DeployExtension>>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/TargetFrameworkMigrator.VS2022/TargetFrameworkMigrator.VS2022.csproj
+++ b/Src/TargetFrameworkMigrator.VS2022/TargetFrameworkMigrator.VS2022.csproj
@@ -56,10 +56,10 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.1.32210.191" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3177-preview3">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Src/TargetFrameworkMigrator/TargetFrameworkMigrator.csproj
+++ b/Src/TargetFrameworkMigrator/TargetFrameworkMigrator.csproj
@@ -26,6 +26,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+	<DeployExtension>>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
+++ b/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
@@ -26,6 +26,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+	<DeployExtension>>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
+++ b/Src/TargetFrameworkMigratorVSIX.VS2022/TargetFrameworkMigratorVSIX.VS2022.csproj
@@ -56,10 +56,10 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.1.32210.191" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3177-preview3">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Src/TargetFrameworkMigratorVSIX/TargetFrameworkMigratorVSIX.csproj
+++ b/Src/TargetFrameworkMigratorVSIX/TargetFrameworkMigratorVSIX.csproj
@@ -46,7 +46,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TargetFrameworkMigrator</RootNamespace>
     <AssemblyName>TargetFrameworkMigrator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -99,7 +99,7 @@
     <ProjectReference Include="..\TargetFrameworkMigrator\TargetFrameworkMigrator.csproj">
       <Project>{39cec1d1-affa-4e29-9f6d-f5e976207274}</Project>
       <Name>TargetFrameworkMigrator</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>	
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ skip_branch_with_pr: true
 image: Visual Studio 2019
 configuration: Release
 before_build:
-- nuget restore TargetFrameworkMigrator.sln
+- nuget restore TargetFrameworkMigrator.sln -verbosity quiet
 build:
   project: TargetFrameworkMigrator.sln
   parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ skip_tags: true
 skip_branch_with_pr: true
 image: Visual Studio 2019
 configuration: Release
+before_build:
+- nuget restore TargetFrameworkMigrator.sln
 build:
   project: TargetFrameworkMigrator.sln
   parallel: true


### PR DESCRIPTION
This PR is a response to https://github.com/TargetFrameworkMigrator/TargetFrameworkMigrator/pull/102

I noticed that the logfile of the failing PR-build indicates that multiple namespaces can not be validated because assemblies might be missing. I opened the solution and noticed that all these namespaces are from nuget-packages. These packages are restored automatically by the visual studio client but not in the build process.

In this PR i try to update the appveyor.yml to include the missing step that is required to restore the nuget packages in the build process